### PR TITLE
Debug delayed notifier in docker compose

### DIFF
--- a/5_eventbooker/configs/notifier.yaml
+++ b/5_eventbooker/configs/notifier.yaml
@@ -13,6 +13,7 @@ rabbitmq:
   port: "5672"
   username: "user"
   password: $RABBITMQ_PASSWORD
+  queue_name: "delayed_notifications"
 
 kafka:
   broker: "kafka:9092"


### PR DESCRIPTION
Add `rabbitmq.queue_name` to notifier config to fix delayed notifier not processing messages from eventbooker.

The notifier's RabbitMQ configuration was missing `rabbitmq.queue_name`, causing it to declare a server-named queue but then attempt to publish and consume using an empty queue name. This resulted in messages not being routed correctly, preventing the delayed notifier from processing events from eventbooker. Explicitly setting `delayed_notifications` ensures consistent queue usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-460992f3-83b8-444b-ad92-2f4c557c84ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-460992f3-83b8-444b-ad92-2f4c557c84ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

